### PR TITLE
fixed url for Benson Music

### DIFF
--- a/rh/rh.tex
+++ b/rh/rh.tex
@@ -2299,7 +2299,7 @@ Another way is to simply record the {\em five} numbers: the {\em
 be roughly the way our ear processes such a sound when we hear it \footnote{%
 We recommend downloading Dave Benson's marvelous book
 {\em Music: A Mathematical Offering} from
-\url{http://www.maths.abdn.ac.uk/~bensondj/html/music.pdf}.
+\url{https://homepages.abdn.ac.uk/mth192/pages/html/maths-music.html}.
 This is free, and gives a beautiful account of the superb
 mechanism of hearing, and of the mathematics of music.}.
 


### PR DESCRIPTION
The pdf location had changed, and the book has since been published in hardcopy, so I changed the url to point to the main page, which includes information about both.